### PR TITLE
Removed Focus Outline for Buttons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,9 @@
                 overflow-x: hidden;
                 word-wrap: break-word;
             }
+            .btn:focus {
+                outline: none;
+            }
         </style>
     </head>
     <body>

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
     <body>
         <div class="row">
             <div class="col-md-2">
-                <button type="button" id="toggleNotifs" class="btn btn-default active">Notifications Off</button>
+                <button type="button" id="toggleNotifs" class="btn btn-default">Notifications Off</button>
             </div>
             <div class="col-md-2 col-md-offset-3">
                 <form id="nameForm" action="">
@@ -94,11 +94,9 @@
             $('#toggleNotifs').click(function() {
                 if (notifsOn) {
                     $('#toggleNotifs').html('Notifications On');
-                    $('#toggleNotifs').className = "btn btn-default active";
                     notifsOn = false;
                 } else {
                     $('#toggleNotifs').html('Notifications Off');
-                    $('#toggleNotifs').className = "btn btn-default";
                     notifsOn = true;
                 }
             });

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
     <body>
         <div class="row">
             <div class="col-md-2">
-                <button type="button" id="toggleNotifs" class="btn btn-default">Notifications Off</button>
+                <button type="button" id="toggleNotifs" class="btn btn-default active">Notifications Off</button>
             </div>
             <div class="col-md-2 col-md-offset-3">
                 <form id="nameForm" action="">
@@ -94,9 +94,11 @@
             $('#toggleNotifs').click(function() {
                 if (notifsOn) {
                     $('#toggleNotifs').html('Notifications On');
+                    $('#toggleNotifs').className = "btn btn-default active";
                     notifsOn = false;
                 } else {
                     $('#toggleNotifs').html('Notifications Off');
+                    $('#toggleNotifs').className = "btn btn-default";
                     notifsOn = true;
                 }
             });


### PR DESCRIPTION
You know that blue outline when you select something?
You know how it always lingers around a button until you click away?

I killed it.
